### PR TITLE
Updated example (and js code)

### DIFF
--- a/example_with_mods
+++ b/example_with_mods
@@ -75,14 +75,15 @@
                             
                         }).disableSelection();
                     }
-                })
+                });
             };
             $.fn.multiselectable.defaults = {
                 click: function(event, elem){},
                 selectedClass: 'selected'
             };
             $.fn.multisortable = function(options) {
-                var mySelectClass;
+                var mySelectClass,
+                    settings;
                 
                 options = options || {};
                 settings = $.extend({}, $.fn.multisortable.defaults, options);
@@ -99,23 +100,23 @@
                         };     
                             
                     if (selectedItems.length > 0) {
-                        myIndex = item.data('i'),
+                        myIndex = item.data('i');
         
                         itemsBefore = selectedItems.filter(function() {
                             return $(this).data('i') < myIndex;
-                        }).css(nullCSS)
+                        }).css(nullCSS);
                         
-                        item.before(itemsBefore)
+                        item.before(itemsBefore);
                         
                         itemsAfter = selectedItems.filter(function() {
                             return $(this).data('i') > myIndex;
-                        }).css(nullCSS)
+                        }).css(nullCSS);
                         
-                        item.after(itemsAfter)
+                        item.after(itemsAfter);
                         
                         setTimeout(function(){
-                            itemsAfter.add(itemsBefore).addClass(mySelectClass)
-                        }, 0)
+                            itemsAfter.add(itemsBefore).addClass(mySelectClass);
+                        }, 0);
                     }
                 }
                 
@@ -146,12 +147,12 @@
                         }
                         
                         settings.start(event, ui);
-                    }
+                    };
                     
                     options.stop = function(event, ui) {
                         regroup(ui.item, ui.item.parent());
                         settings.stop(event, ui);
-                    }
+                    };
                     
                     options.sort = function(event, ui) {
                         var ui_item = ui.item,
@@ -177,7 +178,7 @@
                             height += item.outerHeight();
                             newCSS.top = top - height;
                             item.css(newCSS);
-                        })
+                        });
                         
                         height = ui_item.outerHeight();
                         selectedItems.filter(function() {
@@ -187,18 +188,18 @@
                             newCSS.top = top + height;
                             item.css(newCSS);
                             height += item.outerHeight();
-                        })
+                        });
                         
                         settings.sort(event, ui);
-                    }
+                    };
                     
                     options.receive = function(event, ui) {
                         regroup(ui.item, ui.sender);
                         settings.receive(event, ui);
-                    }
+                    };
                     
                     list.sortable(options).disableSelection();
-                })
+                });
             };
             $.fn.multisortable.defaults = {
                 start: function(event, ui) { },

--- a/example_with_mods
+++ b/example_with_mods
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" type="text/javascript"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" type="text/javascript"></script>
+    <script type="text/javascript">
+         // jquery.multisortable.js - v0.1.3
+         // https://github.com/iamvery/jquery.multisortable
+         // Author: Ethan Atlakson, Jay Hayes -  Last Revision 3/16/2012
+         // multi-selectable, multi-sortable jQuery plugin
+         
+         // Edited by Nick Potten 1/16/2013 and forked to https://github.com/nickelodeon/jquery.multisortable
+        (function($) {
+            $.fn.multiselectable = function(options) {
+                options = options || {};
+                options = $.extend({}, $.fn.multiselectable.defaults, options);
+                
+                return this.each(function() {
+                    var list_children = $(this).children(),
+                        mySelectClass = options.selectedClass;
+                    
+                    // Initialize the list (if not already done)
+                    if (!list_children.data('multiselectable')) {
+                        list_children.data('multiselectable', true);
+                        
+                        // Core handler 
+                        list_children.on('mousedown', function(e) {
+                            var item = $(this),                 // This <li> or equivalent
+                                parent = item.parent(),         // Parent is the <ul> or equivalent
+                                children = parent.children(),   // All <li> elements or equivalent
+                                myIndex = children.index(item),
+                                prev = children.filter('.multiselectable-previous'), // Last chosen item before this one
+                                prevIndex = children.index(prev);
+
+                            // 1. Meta/Ctrl Click 
+                            //    Toggle item (and any .child items under it) whilst leaving selects intact
+                            if (e.ctrlKey || e.metaKey) {
+                                if (item.not('.child').length) {
+                                    if (item.hasClass(mySelectClass)) {
+                                        item.removeClass(mySelectClass)
+                                            .nextUntil(':not(.child)').removeClass(mySelectClass);
+                                    } else {
+                                        item.addClass(mySelectClass)
+                                            .nextUntil(':not(.child)').addClass(mySelectClass);
+                                    }                                    
+                                }
+                                prev.removeClass('multiselectable-previous');
+                                item.addClass('multiselectable-previous');                                
+                                options.click(e, item);
+
+                            // 2. Click or shift-click on non-selected item 
+                            } else if (!item.hasClass(mySelectClass)) {
+                                children.removeClass(mySelectClass);    // Unselect all
+                                item.addClass(mySelectClass);           // Select this item
+
+                                // Shift click to create select range - deselects items outside range
+                                if (e.shiftKey && prevIndex >= 0) {
+                                    // 1. Reselect previous
+                                    prev.addClass(mySelectClass);
+                                    // 2. Select all elements between item & prev
+                                    if (prevIndex < myIndex) {
+                                        item.prevUntil('.multiselectable-previous').addClass(mySelectClass);
+                                    } else if (prevIndex > myIndex) {
+                                        item.nextUntil('.multiselectable-previous').addClass(mySelectClass);
+                                    }
+                                }
+
+                                // Following three lines duplicate above, but it's easier and clearer this way.
+                                prev.removeClass('multiselectable-previous');
+                                item.addClass('multiselectable-previous');
+                                options.click(e, item);
+                            }
+                            // 3. else... if click on selected item and not meta/ctrl, do nothing!
+                            //      Note: meta/ctrl click serves as unselect
+                            
+                        }).disableSelection();
+                    }
+                })
+            };
+            $.fn.multiselectable.defaults = {
+                click: function(event, elem){},
+                selectedClass: 'selected'
+            };
+            $.fn.multisortable = function(options) {
+                var mySelectClass;
+                
+                options = options || {};
+                settings = $.extend({}, $.fn.multisortable.defaults, options);
+                mySelectClass = settings.selectedClass;
+                
+                function regroup(item, list) {
+                    var selectedItems = list.children('.' + mySelectClass),
+                        myIndex,
+                        itemsBefore,
+                        itemsAfter,
+                        nullCSS = {
+                            position: '',
+                            width: ''
+                        };     
+                            
+                    if (selectedItems.length > 0) {
+                        myIndex = item.data('i'),
+        
+                        itemsBefore = selectedItems.filter(function() {
+                            return $(this).data('i') < myIndex;
+                        }).css(nullCSS)
+                        
+                        item.before(itemsBefore)
+                        
+                        itemsAfter = selectedItems.filter(function() {
+                            return $(this).data('i') > myIndex;
+                        }).css(nullCSS)
+                        
+                        item.after(itemsAfter)
+                        
+                        setTimeout(function(){
+                            itemsAfter.add(itemsBefore).addClass(mySelectClass)
+                        }, 0)
+                    }
+                }
+                
+                return this.each(function() {
+                    var list = $(this);
+                    
+                    //enable multi-selection
+                    list.multiselectable({selectedClass: mySelectClass, click: settings.click});
+                    
+                    //enable sorting
+                    options.cancel = settings.items + ':not(.' + mySelectClass + ')';
+                    options.placeholder = settings.placeholder;
+                    options.start = function(event, ui) {
+                        var selectedItems,
+                            height; 
+                            
+                        if (ui.item.hasClass(mySelectClass)) {
+                            selectedItems = ui.item.parent().children('.' + mySelectClass);
+                            
+                            //assign indexes to all selected items
+                            selectedItems.each(function(i) {
+                                $(this).data('i', i);
+                            });
+                            
+                            // adjust placeholder size to be size of items
+                            height = selectedItems.length * ui.item.outerHeight();
+                            ui.placeholder.height(height);
+                        }
+                        
+                        settings.start(event, ui);
+                    }
+                    
+                    options.stop = function(event, ui) {
+                        regroup(ui.item, ui.item.parent());
+                        settings.stop(event, ui);
+                    }
+                    
+                    options.sort = function(event, ui) {
+                        var ui_item = ui.item,
+                            parent = ui_item.parent(),
+                            myIndex = ui_item.data('i'),
+                            top = parseInt(ui_item.css('top').replace('px', '')),
+                            left = parseInt(ui_item.css('left').replace('px', '')),
+                            selectedItems = $('.' + mySelectClass, parent),
+                            height = 0,
+                            newCSS = {
+                                left: left,
+                                top: 0,
+                                position: 'absolute',
+                                zIndex: 1000,
+                                width: ui_item.width()
+                            };
+                        
+                        $.fn.reverse = Array.prototype.reverse;
+                        selectedItems.filter(function() {
+                            return $(this).data('i') < myIndex;
+                        }).reverse().each(function() {
+                            var item = $(this);
+                            height += item.outerHeight();
+                            newCSS.top = top - height;
+                            item.css(newCSS);
+                        })
+                        
+                        height = ui_item.outerHeight();
+                        selectedItems.filter(function() {
+                            return $(this).data('i') > myIndex;
+                        }).each(function() {
+                            var item = $(this);
+                            newCSS.top = top + height;
+                            item.css(newCSS);
+                            height += item.outerHeight();
+                        })
+                        
+                        settings.sort(event, ui);
+                    }
+                    
+                    options.receive = function(event, ui) {
+                        regroup(ui.item, ui.sender);
+                        settings.receive(event, ui);
+                    }
+                    
+                    list.sortable(options).disableSelection();
+                })
+            };
+            $.fn.multisortable.defaults = {
+                start: function(event, ui) { },
+                stop: function(event, ui) { },
+                sort: function(event, ui) { },
+                receive: function(event, ui) { },
+                click: function(event, elem) { },
+                selectedClass: 'selected',
+                placeholder: 'placeholder',
+                items: 'li'
+            };
+        }(jQuery));
+    </script>
+ 
+    <script type="text/javascript">
+        jQuery(function($){
+            $('ul.sortable').multisortable({axis:'y'});
+            $('ul#list1').sortable(
+                'option', 
+                'connectWith', 
+                'ul#list2'
+            );
+            $('ul#list2').sortable(
+                'option', 
+                'connectWith', 
+                'ul#list1'
+            );
+        });
+    </script>
+    
+    <style type="text/css">
+        ul{
+            list-style:none;
+            border:solid 1px black;
+            margin:0;
+            padding:0}
+        li.selected { background-color: #eee; }
+        li.child { 
+            margin-left: 20px;
+            width:178px}
+        #centre{
+            width:200px;
+            margin:0 auto;
+            }
+    </style>       
+</head>
+<body>
+    <div id="centre">
+        <h1>jquery.multisortable.js</h1>
+        <p><a href="https://github.com/iamvery/jquery.multisortable">https://github.com/iamvery/jquery.multisortable</a></p>
+
+        <h2>List 1</h2>
+        <ul id="list1" class="sortable">
+            <li>
+                Item 11
+            </li>
+            <li>
+                Item 12
+            </li>
+            <li class="child">
+                Item 12a
+            </li>
+            <li class="child">
+                Item 12b
+            </li>
+            <li>
+                Item 13
+            </li>
+            <li>
+                Item 14
+            </li>
+            <li>
+                Item 15
+            </li>
+        </ul>
+
+        <h2>List 2</h2>
+        <ul id="list2" class="sortable">
+            <li>
+                Item 21
+            </li>
+            <li>
+                Item 22
+            </li>
+            <li class="child">
+                Item 22a
+            </li>
+            <li>
+                Item 23
+            </li>
+            <li>
+                Item 24
+            </li>
+            <li class="child">
+                Item 24a
+            </li>
+        </ul>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
A modified version of the multiselectable/multisortable plugins embedded in the HTML 'example' posted by iamvery on 3/16/12. Major change is use of mousedown (not click) to initiate multiselectable, allowing select and drag in one mouse movement. Deselecting an item now requires ctrl/meta click. Additional changes include caching multiple jQuery objects for speed & minification and collating variable declarations.
