### PR TITLE
cache list_children

### DIFF
--- a/lib/jquery.multisortable.js
+++ b/lib/jquery.multisortable.js
@@ -10,15 +10,15 @@
 !function($){
 	
 	$.fn.multiselectable = function(options) {
-		if (!options) { options = {} }
+		options = options || {}; 
 		options = $.extend({}, $.fn.multiselectable.defaults, options)
 		
 		return this.each(function() {
-			var list = $(this)
+			var list_children = $(this).children();
 			
-			if (!list.children().data('multiselectable')) {
-				list.children().data('multiselectable', true)
-				list.children().click(function(e) {
+			if (!list_children.data('multiselectable')) {
+				list_children.data('multiselectable', true);
+				list_children.click(function(e) {
 					var item = $(this),
 						parent = item.parent(),
 						myIndex = parent.children().index(item),


### PR DESCRIPTION
1. Use logical OR (not if) to ensure options defined
2. Cache list_children for minimisation & speed.

Note: subsequent changes plan to attach data & handler on list, not list.children()
