### PR TITLE
Fix to keep compatibility using JQuery and Prototype Together

### DIFF
--- a/lib/jquery.multisortable.js
+++ b/lib/jquery.multisortable.js
@@ -2,8 +2,8 @@
  * jquery.multisortable.js - v0.1.3
  * https://github.com/iamvery/jquery.multisortable
  *
- * Author: Ethan Atlakson, Jay Hayes
- * Last Revision 3/16/2012
+ * Author: Ethan Atlakson, Jay Hayes, Gabriel Such
+ * Last Revision 3/26/2013
  * multi-selectable, multi-sortable jQuery plugin
 */
 
@@ -129,7 +129,13 @@
 					top = parseInt(ui.item.css('top').replace('px', '')),
 					left = parseInt(ui.item.css('left').replace('px', ''))
 				
-				$.fn.reverse = Array.prototype.reverse
+				// fix to keep compatibility using prototype.js and jquery together
+				if (typeof []._reverse == 'undefined') {
+     				$.fn.reverse = Array.prototype.reverse;
+			    } else {
+    				$.fn.reverse = Array.prototype._reverse;
+				}
+				
 				var height = 0
 				$('.' + settings.selectedClass, parent).filter(function() {
 					return $(this).data('i') < myIndex


### PR DESCRIPTION
Hello,

I am trying to use JQuery Multisortable in a legacy application. But it breaks.

Why? 
The app use prototype and jquery together and the current way that jquery.multisortable call array reverse causes a conflict between jquery and prototype.

What I did?
A tiny fix in the code. But, it resolves this annoying problem.

Thanks for share multisortable, it was really useful to me.
Follow my 2 cents for this project.

Cheers,
Gabriel Such
