### PR TITLE
handle shift + click where prevIndex === myIndex

### DIFF
--- a/src/jquery.multisortable.js
+++ b/src/jquery.multisortable.js
@@ -51,7 +51,7 @@
 				}
 				else if (prevIndex > myIndex) {
 					shift_range = item.nextUntil('.multiselectable-previous').add(prev).add(item);
-				} else
+				} else {
 					shift_range = item;
 				}
 				shift_range.addClass(options.selectedClass).addClass('multiselectable-shift');

--- a/src/jquery.multisortable.js
+++ b/src/jquery.multisortable.js
@@ -51,6 +51,8 @@
 				}
 				else if (prevIndex > myIndex) {
 					shift_range = item.nextUntil('.multiselectable-previous').add(prev).add(item);
+				} else
+					shift_range = item;
 				}
 				shift_range.addClass(options.selectedClass).addClass('multiselectable-shift');
 			}


### PR DESCRIPTION
Currently the error `Cannot read property 'addClass' of undefined` is thrown if you:
1. shift + click option 1
2. shift + click option n
3. shift + click option 1 again

This PR resolves the issue by selecting only option 1.